### PR TITLE
Add import outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ No provider.
 
 | Name | Description |
 |------|-------------|
+| all\_imports | List of all imported YAML configurations |
 | list\_configs | Terraform lists from YAML configurations |
 | map\_configs | Terraform maps from YAML configurations |
 

--- a/README.md
+++ b/README.md
@@ -255,7 +255,8 @@ No provider.
 
 | Name | Description |
 |------|-------------|
-| all\_imports | List of all imported YAML configurations |
+| all\_imports\_list | List of all imported YAML configurations |
+| all\_imports\_map | Map of all imported YAML configurations |
 | list\_configs | Terraform lists from YAML configurations |
 | map\_configs | Terraform maps from YAML configurations |
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -42,7 +42,8 @@ No provider.
 
 | Name | Description |
 |------|-------------|
-| all\_imports | List of all imported YAML configurations |
+| all\_imports\_list | List of all imported YAML configurations |
+| all\_imports\_map | Map of all imported YAML configurations |
 | list\_configs | Terraform lists from YAML configurations |
 | map\_configs | Terraform maps from YAML configurations |
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -42,6 +42,7 @@ No provider.
 
 | Name | Description |
 |------|-------------|
+| all\_imports | List of all imported YAML configurations |
 | list\_configs | Terraform lists from YAML configurations |
 | map\_configs | Terraform maps from YAML configurations |
 

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -7,3 +7,8 @@ output "list_configs" {
   value       = module.yaml_config.list_configs
   description = "Terraform lists from YAML configurations"
 }
+
+output "all_imports" {
+  value       = module.yaml_config.all_imports
+  description = "List of all imported YAML configurations"
+}

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -8,7 +8,12 @@ output "list_configs" {
   description = "Terraform lists from YAML configurations"
 }
 
-output "all_imports" {
-  value       = module.yaml_config.all_imports
+output "all_imports_list" {
+  value       = module.yaml_config.all_imports_list
   description = "List of all imported YAML configurations"
+}
+
+output "all_imports_map" {
+  value       = module.yaml_config.all_imports_map
+  description = "Map of all imported YAML configurations"
 }

--- a/examples/imports-local/config/imports-level-1.yaml
+++ b/examples/imports-local/config/imports-level-1.yaml
@@ -5,10 +5,10 @@ vars:
   stage: prod
 
 terraform:
-  vars:
+  vars: {}
 
 helmfile:
-  vars:
+  vars: {}
 
 components:
   terraform:
@@ -16,7 +16,7 @@ components:
       vars:
         cidr_block: "10.102.0.0/18"
     eks:
-      vars:
+      vars: {}
 
   helmfile:
     nginx-ingress:

--- a/examples/imports-local/config/imports-level-2.yaml
+++ b/examples/imports-local/config/imports-level-2.yaml
@@ -1,12 +1,13 @@
 import:
   - imports-level-3
+  - imports-level-3a
 
 vars:
   region: us-east-2
   environment: ue2
 
 terraform:
-  vars:
+  vars: {}
 
 helmfile:
-  vars:
+  vars: {}

--- a/examples/imports-local/config/imports-level-3.yaml
+++ b/examples/imports-local/config/imports-level-3.yaml
@@ -1,11 +1,14 @@
+import:
+  - imports-level-4
+
 vars:
   namespace: eg
 
 terraform:
-  vars:
+  vars: {}
 
 helmfile:
-  vars:
+  vars: {}
 
 components:
   terraform:

--- a/examples/imports-local/config/imports-level-3a.yaml
+++ b/examples/imports-local/config/imports-level-3a.yaml
@@ -1,0 +1,8 @@
+vars:
+  level: 3
+
+terraform:
+  vars: {}
+
+helmfile:
+  vars: {}

--- a/examples/imports-local/config/imports-level-4.yaml
+++ b/examples/imports-local/config/imports-level-4.yaml
@@ -1,0 +1,8 @@
+vars:
+  level: 4
+
+terraform:
+  vars: {}
+
+helmfile:
+  vars: {}

--- a/examples/imports-local/outputs.tf
+++ b/examples/imports-local/outputs.tf
@@ -7,3 +7,8 @@ output "list_configs" {
   value       = module.yaml_config.list_configs
   description = "Terraform lists from YAML configurations"
 }
+
+output "all_imports" {
+  value       = module.yaml_config.all_imports
+  description = "List of all imported YAML configurations"
+}

--- a/examples/imports-local/outputs.tf
+++ b/examples/imports-local/outputs.tf
@@ -8,7 +8,12 @@ output "list_configs" {
   description = "Terraform lists from YAML configurations"
 }
 
-output "all_imports" {
-  value       = module.yaml_config.all_imports
+output "all_imports_list" {
+  value       = module.yaml_config.all_imports_list
   description = "List of all imported YAML configurations"
+}
+
+output "all_imports_map" {
+  value       = module.yaml_config.all_imports_map
+  description = "Map of all imported YAML configurations"
 }

--- a/examples/imports-remote/outputs.tf
+++ b/examples/imports-remote/outputs.tf
@@ -7,3 +7,8 @@ output "list_configs" {
   value       = module.yaml_config.list_configs
   description = "Terraform lists from YAML configurations"
 }
+
+output "all_imports" {
+  value       = module.yaml_config.all_imports
+  description = "List of all imported YAML configurations"
+}

--- a/examples/imports-remote/outputs.tf
+++ b/examples/imports-remote/outputs.tf
@@ -8,7 +8,12 @@ output "list_configs" {
   description = "Terraform lists from YAML configurations"
 }
 
-output "all_imports" {
-  value       = module.yaml_config.all_imports
+output "all_imports_list" {
+  value       = module.yaml_config.all_imports_list
   description = "List of all imported YAML configurations"
+}
+
+output "all_imports_map" {
+  value       = module.yaml_config.all_imports_map
+  description = "Map of all imported YAML configurations"
 }

--- a/main.tf
+++ b/main.tf
@@ -165,7 +165,7 @@ module "maps_deepmerge" {
 }
 
 locals {
-  all_imports = concat(
+  all_imports_list = concat(
     module.yaml_config_1.all_map_imports,
     module.yaml_config_2.all_map_imports,
     module.yaml_config_3.all_map_imports,
@@ -177,4 +177,17 @@ locals {
     module.yaml_config_9.all_map_imports,
     module.yaml_config_10.all_map_imports
   )
+
+  all_imports_map = {
+    1  = module.yaml_config_1.all_map_imports,
+    2  = module.yaml_config_2.all_map_imports,
+    3  = module.yaml_config_3.all_map_imports,
+    4  = module.yaml_config_4.all_map_imports,
+    5  = module.yaml_config_5.all_map_imports,
+    6  = module.yaml_config_6.all_map_imports,
+    7  = module.yaml_config_7.all_map_imports,
+    8  = module.yaml_config_8.all_map_imports,
+    9  = module.yaml_config_9.all_map_imports,
+    10 = module.yaml_config_10.all_map_imports
+  }
 }

--- a/main.tf
+++ b/main.tf
@@ -163,3 +163,18 @@ module "maps_deepmerge" {
     module.yaml_config_1.map_configs
   ]
 }
+
+locals {
+  all_imports = concat(
+    module.yaml_config_1.all_map_imports,
+    module.yaml_config_2.all_map_imports,
+    module.yaml_config_3.all_map_imports,
+    module.yaml_config_4.all_map_imports,
+    module.yaml_config_5.all_map_imports,
+    module.yaml_config_6.all_map_imports,
+    module.yaml_config_7.all_map_imports,
+    module.yaml_config_8.all_map_imports,
+    module.yaml_config_9.all_map_imports,
+    module.yaml_config_10.all_map_imports
+  )
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,7 +8,12 @@ output "list_configs" {
   description = "Terraform lists from YAML configurations"
 }
 
-output "all_imports" {
-  value       = local.all_imports
+output "all_imports_list" {
+  value       = local.all_imports_list
   description = "List of all imported YAML configurations"
+}
+
+output "all_imports_map" {
+  value       = local.all_imports_map
+  description = "Map of all imported YAML configurations"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,3 +7,8 @@ output "list_configs" {
   value       = module.yaml_config_1.list_configs
   description = "Terraform lists from YAML configurations"
 }
+
+output "all_imports" {
+  value       = local.all_imports
+  description = "List of all imported YAML configurations"
+}


### PR DESCRIPTION
## what
* Add `all_imports_list` and `all_imports_map` outputs

## why
* Output all imported configuration file names as list and map 
* Useful for Terraform Cloud and Spacelift to know which config files are imported by a given stack

## test

```
all_imports_list = [
  "imports-level-2.yaml",
  "imports-level-3.yaml",
  "imports-level-3a.yaml",
  "imports-level-4.yaml",
]
all_imports_map = {
  "1" = [
    "imports-level-2.yaml",
  ]
  "2" = [
    "imports-level-3.yaml",
    "imports-level-3a.yaml",
  ]
  "3" = [
    "imports-level-4.yaml",
  ]
  "4" = []
  "5" = []
  "6" = []
  "7" = []
  "8" = []
  "9" = []
  "10" = []
}
```
