### PR TITLE
Add `map_configs` variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ No provider.
 | map\_config\_local\_base\_path | Base path to local YAML configuration files of map type | `string` | `""` | no |
 | map\_config\_paths | Paths to YAML configuration files of map type | `list(string)` | `[]` | no |
 | map\_config\_remote\_base\_path | Base path to remote YAML configuration files of map type | `string` | `""` | no |
+| map\_configs | List of existing configurations of map type. Deep-merging of the existing map configs takes precedence over the map configs loaded from YAML files | `list(map(any))` | `[]` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
 | parameters | Map of parameters for interpolation within the YAML config templates | `map(string)` | `{}` | no |

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ No provider.
 | map\_config\_local\_base\_path | Base path to local YAML configuration files of map type | `string` | `""` | no |
 | map\_config\_paths | Paths to YAML configuration files of map type | `list(string)` | `[]` | no |
 | map\_config\_remote\_base\_path | Base path to remote YAML configuration files of map type | `string` | `""` | no |
-| map\_configs | List of existing configurations of map type. Deep-merging of the existing map configs takes precedence over the map configs loaded from YAML files | `list(map(any))` | `[]` | no |
+| map\_configs | List of existing configurations of map type. Deep-merging of the existing map configs takes precedence over the map configs loaded from YAML files | `any` | `[]` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
 | parameters | Map of parameters for interpolation within the YAML config templates | `map(string)` | `{}` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -30,6 +30,7 @@ No provider.
 | map\_config\_local\_base\_path | Base path to local YAML configuration files of map type | `string` | `""` | no |
 | map\_config\_paths | Paths to YAML configuration files of map type | `list(string)` | `[]` | no |
 | map\_config\_remote\_base\_path | Base path to remote YAML configuration files of map type | `string` | `""` | no |
+| map\_configs | List of existing configurations of map type. Deep-merging of the existing map configs takes precedence over the map configs loaded from YAML files | `list(map(any))` | `[]` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
 | parameters | Map of parameters for interpolation within the YAML config templates | `map(string)` | `{}` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -30,7 +30,7 @@ No provider.
 | map\_config\_local\_base\_path | Base path to local YAML configuration files of map type | `string` | `""` | no |
 | map\_config\_paths | Paths to YAML configuration files of map type | `list(string)` | `[]` | no |
 | map\_config\_remote\_base\_path | Base path to remote YAML configuration files of map type | `string` | `""` | no |
-| map\_configs | List of existing configurations of map type. Deep-merging of the existing map configs takes precedence over the map configs loaded from YAML files | `list(map(any))` | `[]` | no |
+| map\_configs | List of existing configurations of map type. Deep-merging of the existing map configs takes precedence over the map configs loaded from YAML files | `any` | `[]` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
 | parameters | Map of parameters for interpolation within the YAML config templates | `map(string)` | `{}` | no |

--- a/examples/complete/config/map-configs/map-config-3.yaml
+++ b/examples/complete/config/map-configs/map-config-3.yaml
@@ -1,0 +1,4 @@
+key3:
+  name: name3
+  param: param3
+  type: type3

--- a/examples/complete/fixtures.tfvars
+++ b/examples/complete/fixtures.tfvars
@@ -23,20 +23,30 @@ parameters = {
 map_configs = [
   {
     key3 = {
-      name  = "name3"
-      param = "param3"
-      type  = "type3"
+      name  = "name3_override"
+      param = "param3_override"
     },
     key4 = {
       name  = "name4"
       param = "param4"
       type  = "type4"
     },
-    key5 = [
+    key5 = {
+      name  = "name5"
+      param = ["param5a", "param5b"]
+      type  = "type5"
+    }
+  },
+  {
+    key6 = {
+      name  = "name6"
+      param = "param6"
+      type  = "type6"
+    },
+    key1 = [
       {
-        name  = "name5"
-        param = "param5"
-        type  = "type5"
+        name  = "name1_override"
+        param = "param1_override"
       }
     ]
   }

--- a/examples/complete/fixtures.tfvars
+++ b/examples/complete/fixtures.tfvars
@@ -19,3 +19,25 @@ parameters = {
   param1 = "1"
   param2 = "2"
 }
+
+map_configs = [
+  {
+    key3 = {
+      name  = "name3"
+      param = "param3"
+      type  = "type3"
+    },
+    key4 = {
+      name  = "name4"
+      param = "param4"
+      type  = "type4"
+    },
+    key5 = [
+      {
+        name  = "name5"
+        param = "param5"
+        type  = "type5"
+      }
+    ]
+  }
+]

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -9,6 +9,8 @@ module "yaml_config" {
   list_config_remote_base_path = var.list_config_remote_base_path
   list_config_paths            = var.list_config_paths
 
+  map_configs = var.map_configs
+
   parameters = var.parameters
 
   context = module.this.context

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -45,3 +45,9 @@ variable "remote_config_selector" {
   description = "String to detect local vs. remote config paths"
   default     = "://"
 }
+
+variable "map_configs" {
+  type        = list(map(any))
+  description = "List of existing configurations of map type. Deep-merging of the existing map configs takes precedence over the map configs loaded from YAML files"
+  default     = []
+}

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -47,7 +47,7 @@ variable "remote_config_selector" {
 }
 
 variable "map_configs" {
-  type        = list(map(any))
+  type        = any
   description = "List of existing configurations of map type. Deep-merging of the existing map configs takes precedence over the map configs loaded from YAML files"
   default     = []
 }

--- a/examples/imports-local/main.tf
+++ b/examples/imports-local/main.tf
@@ -9,6 +9,8 @@ module "yaml_config" {
   list_config_remote_base_path = var.list_config_remote_base_path
   list_config_paths            = var.list_config_paths
 
+  map_configs = var.map_configs
+
   parameters = var.parameters
 
   context = module.this.context

--- a/examples/imports-local/variables.tf
+++ b/examples/imports-local/variables.tf
@@ -45,3 +45,9 @@ variable "remote_config_selector" {
   description = "String to detect local vs. remote config paths"
   default     = "://"
 }
+
+variable "map_configs" {
+  type        = list(map(any))
+  description = "List of existing configurations of map type. Deep-merging of the existing map configs takes precedence over the map configs loaded from YAML files"
+  default     = []
+}

--- a/examples/imports-local/variables.tf
+++ b/examples/imports-local/variables.tf
@@ -47,7 +47,7 @@ variable "remote_config_selector" {
 }
 
 variable "map_configs" {
-  type        = list(map(any))
+  type        = any
   description = "List of existing configurations of map type. Deep-merging of the existing map configs takes precedence over the map configs loaded from YAML files"
   default     = []
 }

--- a/examples/imports-remote/main.tf
+++ b/examples/imports-remote/main.tf
@@ -9,6 +9,8 @@ module "yaml_config" {
   list_config_remote_base_path = var.list_config_remote_base_path
   list_config_paths            = var.list_config_paths
 
+  map_configs = var.map_configs
+
   parameters = var.parameters
 
   context = module.this.context

--- a/examples/imports-remote/variables.tf
+++ b/examples/imports-remote/variables.tf
@@ -45,3 +45,9 @@ variable "remote_config_selector" {
   description = "String to detect local vs. remote config paths"
   default     = "://"
 }
+
+variable "map_configs" {
+  type        = list(map(any))
+  description = "List of existing configurations of map type. Deep-merging of the existing map configs takes precedence over the map configs loaded from YAML files"
+  default     = []
+}

--- a/examples/imports-remote/variables.tf
+++ b/examples/imports-remote/variables.tf
@@ -47,7 +47,7 @@ variable "remote_config_selector" {
 }
 
 variable "map_configs" {
-  type        = list(map(any))
+  type        = any
   description = "List of existing configurations of map type. Deep-merging of the existing map configs takes precedence over the map configs loaded from YAML files"
   default     = []
 }

--- a/main.tf
+++ b/main.tf
@@ -150,18 +150,21 @@ module "yaml_config_10" {
 module "maps_deepmerge" {
   source = "./modules/deepmerge"
 
-  maps = [
-    module.yaml_config_10.map_configs,
-    module.yaml_config_9.map_configs,
-    module.yaml_config_8.map_configs,
-    module.yaml_config_7.map_configs,
-    module.yaml_config_6.map_configs,
-    module.yaml_config_5.map_configs,
-    module.yaml_config_4.map_configs,
-    module.yaml_config_3.map_configs,
-    module.yaml_config_2.map_configs,
-    module.yaml_config_1.map_configs
-  ]
+  maps = concat(
+    [
+      module.yaml_config_10.map_configs,
+      module.yaml_config_9.map_configs,
+      module.yaml_config_8.map_configs,
+      module.yaml_config_7.map_configs,
+      module.yaml_config_6.map_configs,
+      module.yaml_config_5.map_configs,
+      module.yaml_config_4.map_configs,
+      module.yaml_config_3.map_configs,
+      module.yaml_config_2.map_configs,
+      module.yaml_config_1.map_configs
+    ],
+    var.map_configs
+  )
 }
 
 locals {

--- a/variables.tf
+++ b/variables.tf
@@ -45,3 +45,9 @@ variable "remote_config_selector" {
   description = "String to detect local vs. remote config paths"
   default     = "://"
 }
+
+variable "map_configs" {
+  type        = list(map(any))
+  description = "List of existing configurations of map type. Deep-merging of the existing map configs takes precedence over the map configs loaded from YAML files"
+  default     = []
+}

--- a/variables.tf
+++ b/variables.tf
@@ -47,7 +47,7 @@ variable "remote_config_selector" {
 }
 
 variable "map_configs" {
-  type        = list(map(any))
+  type        = any
   description = "List of existing configurations of map type. Deep-merging of the existing map configs takes precedence over the map configs loaded from YAML files"
   default     = []
 }


### PR DESCRIPTION
## what
* Add `map_configs` variable

## why
* `map_configs` variable is a list of existing configurations of map type. Deep-merging of the existing map configs takes precedence over the map configs loaded from YAML files 
* Allow deep-merging of Terraform maps without loading them from YAML files (e.g. when using stack configs from other modules, we need to deep-merge `vars` sections from different parts of YAML files)
* Allow re-using the third-party `deepmerge`  from other modules when they already use `terraform-yaml-config` (since Terraform does not support deep-merging natively)  - and not copying the `deepmerge` module into every other module that need deep-merging


## test

### Input 

```
map_config_paths = [
  "map-configs/*.yaml"
]

map_configs = [
  {
    key3 = {
      name  = "name3_override"
      param = "param3_override"
    },
    key4 = {
      name  = "name4"
      param = "param4"
      type  = "type4"
    },
    key5 = {
      name  = "name5"
      param = ["param5a", "param5b"]
      type  = "type5"
    }
  },
  {
    key6 = {
      name  = "name6"
      param = "param6"
      type  = "type6"
    },
    key1 = [
      {
        name  = "name1_override"
        param = "param1_override"
      }
    ]
  }
]
```

### Output
```
Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

Outputs:


map_configs = {
  "key1" = [
    {
      "name" = "name1_override"
      "param" = "param1_override"
    },
  ]
  "key2" = [
    {
      "name" = "name2"
      "param" = "2"
      "type" = "type2"
    },
  ]
  "key3" = {
    "name" = "name3_override"
    "param" = "param3_override"
    "type" = "type3"
  }
  "key4" = {
    "name" = "name4"
    "param" = "param4"
    "type" = "type4"
  }
  "key5" = {
    "name" = "name5"
    "param" = [
      "param5a",
      "param5b",
    ]
    "type" = "type5"
  }
  "key6" = {
    "name" = "name6"
    "param" = "param6"
    "type" = "type6"
  }
```
