### PR TITLE
Use deep-merge for imports at the same level

### DIFF
--- a/examples/imports-local/config/imports-level-2.yaml
+++ b/examples/imports-local/config/imports-level-2.yaml
@@ -7,7 +7,12 @@ vars:
   environment: ue2
 
 terraform:
-  vars: {}
+  vars:
+    var_1: 1_override
+    var_2: 2_override
 
 helmfile:
-  vars: {}
+  vars:
+    var_1: 1
+    var_2: 2
+

--- a/examples/imports-local/config/imports-level-3.yaml
+++ b/examples/imports-local/config/imports-level-3.yaml
@@ -5,7 +5,9 @@ vars:
   namespace: eg
 
 terraform:
-  vars: {}
+  vars:
+    var_1: 1
+    var_3: 3
 
 helmfile:
   vars: {}

--- a/examples/imports-local/config/imports-level-3a.yaml
+++ b/examples/imports-local/config/imports-level-3a.yaml
@@ -2,7 +2,10 @@ vars:
   level: 3
 
 terraform:
-  vars: {}
+  vars:
+    var_1: 1a
+    var_2: 2a
+    var_3: 3a
 
 helmfile:
   vars: {}

--- a/modules/yaml-config/outputs.tf
+++ b/modules/yaml-config/outputs.tf
@@ -1,5 +1,5 @@
 output "map_configs" {
-  value       = local.all_map_configs
+  value       = module.all_map_configs.merged
   description = "Terraform maps from YAML configurations"
 }
 


### PR DESCRIPTION
## what
* Use deep-merge for imports at the same level

## why
* When providing multiple imports at the same level, we need to deep-merge them as well in the declaration order

```
import:
  - imports-level-3
  - imports-level-3a
```

* Don't use Terraform `merge` anywhere in the code since it does not do deep-merging

## test

```
Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

Outputs:

all_imports_list = [
  "imports-level-2.yaml",
  "imports-level-3.yaml",
  "imports-level-3a.yaml",
  "imports-level-4.yaml",
]
all_imports_map = {
  "1" = [
    "imports-level-2.yaml",
  ]
  "10" = []
  "2" = [
    "imports-level-3.yaml",
    "imports-level-3a.yaml",
  ]
  "3" = [
    "imports-level-4.yaml",
  ]
  "4" = []
  "5" = []
  "6" = []
  "7" = []
  "8" = []
  "9" = []
}
list_configs = []
map_configs = {
  "components" = {
    "helmfile" = {
      "nginx-ingress" = {
        "vars" = {
          "installed" = true
        }
      }
    }
    "terraform" = {
      "eks" = {
        "backend" = {
          "s3" = {
            "workspace_key_prefix" = "eks"
          }
        }
        "vars" = {
          "cluster_kubernetes_version" = "1.18"
        }
      }
      "vpc" = {
        "backend" = {
          "s3" = {
            "workspace_key_prefix" = "vpc"
          }
        }
        "vars" = {
          "cidr_block" = "10.102.0.0/18"
        }
      }
    }
  }
  "helmfile" = {
    "vars" = {
      "var_1" = 1
      "var_2" = 2
    }
  }
  "import" = [
    "imports-level-2",
  ]
  "terraform" = {
    "vars" = {
      "var_1" = "1_override"
      "var_2" = "2_override"
      "var_3" = "3a"
    }
  }
  "vars" = {
    "environment" = "ue2"
    "level" = 3
    "namespace" = "eg"
    "region" = "us-east-2"
    "stage" = "prod"
  }
}
```
