### PR TITLE
Terraform template_file remediation

### DIFF
--- a/modules/deepmerge/versions.tf
+++ b/modules/deepmerge/versions.tf
@@ -2,10 +2,6 @@ terraform {
   required_version = ">= 0.13.0"
 
   required_providers {
-    template = {
-      source  = "hashicorp/template"
-      version = ">= 2.2"
-    }
     http = {
       source  = "hashicorp/http"
       version = ">= 2.0"

--- a/modules/yaml-config/main.tf
+++ b/modules/yaml-config/main.tf
@@ -24,7 +24,7 @@ locals {
     [
       for path in local.remote_map_config_paths : {
         #for k, v in yamldecode(data.template_file.remote_config[base64encode(path)].rendered) : k => v
-        for k, v in yamldecode(templatefile(local.remote_config_fixed[base64encode(path)].response_body, var.parameters)) : k => v 
+        for k, v in yamldecode(templatefile(local.remote_configs[base64encode(path)].response_body, var.parameters)) : k => v 
       }
     ]
   )
@@ -50,7 +50,7 @@ locals {
     for path in var.list_config_paths : path if replace(path, var.remote_config_selector, "") != path
   ] : []
 
-  remote_config_fixed = {
+  remote_configs = {
     for k, v in data.http.remote_config : base64encode(v.value.id) =>  {
       response_body = v.value.response_body
     } if module.this.enabled
@@ -60,7 +60,7 @@ locals {
   remote_list_configs = flatten(
     [
       for c in local.remote_list_config_paths : [
-        for k, v in yamldecode(templatefile(local.remote_config_fixed[base64encode(c)].response_body, var.parameters)) : v
+        for k, v in yamldecode(templatefile(local.remote_configs[base64encode(c)].response_body, var.parameters)) : v
       ]
     ]
   )

--- a/modules/yaml-config/main.tf
+++ b/modules/yaml-config/main.tf
@@ -90,11 +90,11 @@ data "http" "remote_config" {
 }
 
 # Render all remote configs as templates using the supplied map of template variables
-data "template_file" "remote_config" {
-  for_each = module.this.enabled ? data.http.remote_config : {}
-  template = try(each.value.body, "")
-  vars     = var.parameters
-}
+#data "template_file" "remote_config" {
+#  for_each = module.this.enabled ? data.http.remote_config : {}
+#  template = try(each.value.body, "")
+#  vars     = var.parameters
+#}
 
 module "deep_merge" {
   source                 = "../deepmerge"

--- a/modules/yaml-config/versions.tf
+++ b/modules/yaml-config/versions.tf
@@ -2,10 +2,6 @@ terraform {
   required_version = ">= 0.13.0"
 
   required_providers {
-    template = {
-      source  = "hashicorp/template"
-      version = ">= 2.2"
-    }
     http = {
       source  = "hashicorp/http"
       version = ">= 2.0"

--- a/versions.tf
+++ b/versions.tf
@@ -6,10 +6,6 @@ terraform {
       source  = "hashicorp/local"
       version = ">= 1.3"
     }
-    template = {
-      source  = "hashicorp/template"
-      version = ">= 2.2"
-    }
     http = {
       source  = "hashicorp/http"
       version = ">= 2.0"


### PR DESCRIPTION
## what
* All references to the deprecated `hashicorp/template` module have been replaced with the in-built function `templatefile`

## why
* The `hashicorp/template` module has been retired by HashiCorp.  It is no longer under development.
* Users with modern Macbook ARM processors, such as the M1, cannot utilize this module, as it has no `arm64` build.

## references
* `closes #17`
* https://github.com/cloudposse/terraform-yaml-config/issues/17

